### PR TITLE
fix: corrige função para deletar usuário (deleteUser())

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -143,24 +143,8 @@ function myEscope(){
 
     window.deleteUser = function(index) {
         users.splice(index, 1); 
-
-        const containerCard = document.querySelector('.container-card-user');
-        containerCard.innerHTML = '';
-
-        for (let i = 0; i < users.length; i++) {
-            createCard();
-        }
-
-        const cardUser = document.querySelectorAll('.card-user');
-        for (let i = 0; i < users.length; i++) {
-            const { name, age, gender } = users[i];
-            cardUser[i].innerHTML = `
-                <p>${name}</p>
-                <p>${age}</p>
-                <p>${gender}</p>
-                <button onClick="deleteUser(${i})">Deletar</button>
-            `;
-        }
+        toStringfy(users)
+        renderUsertoScreen(users);
     }
 
     


### PR DESCRIPTION
### Contexto

Antes desta correção, ao deletar um usuário, os cards da galeria estavam sendo re-renderizados de forma incorreta — exibindo dados inconsistentes ou duplicados.

### O que foi feito

- Corrigida a lógica de atualização da lista de usuários após exclusão
- Garantido que os cards restantes sejam renderizados corretamente com os dados atualizados vindo diretamente do localStorage
- Agora a função deleteUser() também exclui o usuário do localStorage. 

### Observações

- Esta PR parte da branch `feat-deletar-usuario`
- A correção foi testada no Chrome
